### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like the clear focus on building a robust framework for industrial problem-solving using neurosymbolic AI. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] LangChain project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   In AGENTS.md/CLAUDE.md, There is no documentation outlining guidance for configuring agents. This can make it difficult for developers to understand how to best utilize the agent capabilities within the framework.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)